### PR TITLE
Allow CORS from Any Origin

### DIFF
--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -24,12 +24,13 @@ import javax.annotation.Nullable
 
 import scala.collection.JavaConverters._
 
-import com.linecorp.armeria.common.{HttpData, HttpHeaderNames, HttpHeaders, HttpRequest, HttpResponse, HttpStatus, MediaType, ResponseHeaders, ResponseHeadersBuilder}
+import com.linecorp.armeria.common.{HttpData, HttpHeaderNames, HttpHeaders, HttpMethod, HttpRequest, HttpResponse, HttpStatus, MediaType, ResponseHeaders, ResponseHeadersBuilder}
 import com.linecorp.armeria.common.auth.OAuth2Token
 import com.linecorp.armeria.internal.server.ResponseConversionUtil
 import com.linecorp.armeria.server.{Server, ServiceRequestContext}
 import com.linecorp.armeria.server.annotation.{ConsumesJson, Default, ExceptionHandler, ExceptionHandlerFunction, Get, Head, Param, Post, ProducesJson}
 import com.linecorp.armeria.server.auth.AuthService
+import com.linecorp.armeria.server.cors.CorsService
 import io.delta.standalone.internal.DeltaSharedTableLoader
 import net.sourceforge.argparse4j.ArgumentParsers
 import org.apache.commons.io.FileUtils
@@ -241,6 +242,14 @@ object DeltaSharingService {
   }
 
   def start(serverConfig: ServerConfig): Server = {
+    val corsService =
+      CorsService.builderForAnyOrigin()
+        .allowCredentials()
+        .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
+        .allowRequestHeaders("allow_request_header")
+        .exposeHeaders("expose_header_1", "expose_header_2")
+        .preflightResponseHeader("x-preflight-cors", "Hello CORS")
+        .newDecorator();
     lazy val server = {
       updateDefaultJsonPrinterForScalaPbConverterUtil()
       val builder = Server.builder()
@@ -248,6 +257,7 @@ object DeltaSharingService {
         .disableDateHeader()
         .disableServerHeader()
         .annotatedService(serverConfig.endpoint, new DeltaSharingService(serverConfig): Any)
+        .decorator(corsService)
       if (serverConfig.ssl == null) {
         builder.http(serverConfig.getPort)
       } else {

--- a/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
+++ b/server/src/main/scala/io/delta/sharing/server/DeltaSharingService.scala
@@ -242,7 +242,7 @@ object DeltaSharingService {
   }
 
   def start(serverConfig: ServerConfig): Server = {
-    val corsService =
+    lazy val corsService =
       CorsService.builderForAnyOrigin()
         .allowCredentials()
         .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)


### PR DESCRIPTION
The scope of these changes are to enable any web application to call the Delta Sharing reference implementation server. We modified the DeltaSharingService to enable CORS on any origin for any HTTP request following the [Armeria guide](https://armeria.dev/docs/server-cors/).


Existing tests pass, no new tests were added.