### PR TITLE
Sampling pushdown for Python Delta Sharing client

### DIFF
--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -49,7 +49,7 @@ def _parse_url(url: str) -> Tuple[str, str, str, str]:
     return (profile, share, schema, table)
 
 
-def load_as_pandas(url: str, limit: Optional[int] = None) -> pd.DataFrame:
+def load_as_pandas(url: str, limit: Optional[int] = None, sampleFraction: Optional[float] = None) -> pd.DataFrame:
     """
     Load the shared table using the give url as a pandas DataFrame.
 
@@ -65,6 +65,7 @@ def load_as_pandas(url: str, limit: Optional[int] = None) -> pd.DataFrame:
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
         limit=limit,
+        sampleFraction=sampleFraction,
     ).to_pandas()
 
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -69,7 +69,6 @@ class DeltaSharingReader:
         response = self._rest_client.list_files_in_table(
             self._table, predicateHints=self._predicateHints, limitHint=self._limit, sampleFraction=self._sampleFraction
         )
-        print(len(response.add_files))
 
         schema_json = loads(response.metadata.schema_string)
 

--- a/python/delta_sharing/reader.py
+++ b/python/delta_sharing/reader.py
@@ -34,6 +34,7 @@ class DeltaSharingReader:
         *,
         predicateHints: Optional[Sequence[str]] = None,
         limit: Optional[int] = None,
+        sampleFraction: Optional[float] = None,
     ):
         self._table = table
         self._rest_client = rest_client
@@ -47,20 +48,28 @@ class DeltaSharingReader:
             assert isinstance(limit, int) and limit >= 0, "'limit' must be a non-negative int"
         self._limit = limit
 
+        if sampleFraction is not None:
+            assert isinstance(sampleFraction, float) and sampleFraction >= 0.0 and sampleFraction <= 1.0, "'sampleFraction' must be between 0.0 and 1.0"
+        self._sampleFraction = sampleFraction
+
     @property
     def table(self) -> Table:
         return self._table
 
     def predicateHints(self, predicateHints: Optional[Sequence[str]]) -> "DeltaSharingReader":
-        return self._copy(predicateHints=predicateHints, limit=self._limit)
+        return self._copy(predicateHints=predicateHints, limit=self._limit, sampleFraction=self._sampleFraction)
 
     def limit(self, limit: Optional[int]) -> "DeltaSharingReader":
-        return self._copy(predicateHints=self._predicateHints, limit=limit)
+        return self._copy(predicateHints=self._predicateHints, limit=limit, sampleFraction=self._sampleFraction)
+
+    def sample(self, sampleFraction: Optional[float]) -> "DeltaSharingReader":
+        return self._copy(predicateHints=self._predicateHints, limit=self._limit, sampleFraction=sampleFraction)
 
     def to_pandas(self) -> pd.DataFrame:
         response = self._rest_client.list_files_in_table(
-            self._table, predicateHints=self._predicateHints, limitHint=self._limit
+            self._table, predicateHints=self._predicateHints, limitHint=self._limit, sampleFraction=self._sampleFraction
         )
+        print(len(response.add_files))
 
         schema_json = loads(response.metadata.schema_string)
 
@@ -94,13 +103,14 @@ class DeltaSharingReader:
         )[[field["name"] for field in schema_json["fields"]]]
 
     def _copy(
-        self, *, predicateHints: Optional[Sequence[str]], limit: Optional[int]
+        self, *, predicateHints: Optional[Sequence[str]], limit: Optional[int], sampleFraction: Optional[float]
     ) -> "DeltaSharingReader":
         return DeltaSharingReader(
             table=self._table,
             rest_client=self._rest_client,
             predicateHints=predicateHints,
             limit=limit,
+            sampleFraction=sampleFraction,
         )
 
     @staticmethod

--- a/python/delta_sharing/rest_client.py
+++ b/python/delta_sharing/rest_client.py
@@ -244,12 +244,15 @@ class DataSharingRestClient:
         *,
         predicateHints: Optional[Sequence[str]] = None,
         limitHint: Optional[int] = None,
+        sampleFraction: Optional[float] = None,
     ) -> ListFilesInTableResponse:
         data: Dict = {}
         if predicateHints is not None:
             data["predicateHints"] = predicateHints
         if limitHint is not None:
             data["limitHint"] = limitHint
+        if sampleFraction is not None:
+            data["sampleFraction"] = {"precisionFrom": 0.0, "precisionTo": sampleFraction}
 
         with self._post_internal(
             f"/shares/{table.share}/schemas/{table.schema}/tables/{table.name}/query",


### PR DESCRIPTION
Python client can now give a sampling hint to the Sharing Server. The idea is that by defining a sampling hint, the Sharing Server can reduce the number of files to be read by the client notably. It allows users to know what a dataset looks like without loading everything.

```python
df = delta_sharing.load_as_pandas(table_url, sampleFraction=0.1)
```